### PR TITLE
Guías de agentes alineadas a Godot y referencia de assets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 Este repositorio explora un **RPG pequeño** con mentalidad de **ingeniería de sistemas**, no de lista de features. Cualquier chat de Cursor en este repo debe alinear propuestas con esta visión.
 
+**Motor:** el desarrollo se orienta a **Godot 4.x**. Las recomendaciones de implementación deben ser **idiomáticas** (escenas/nodos, `_physics_process` vs `_process`, señales, `Resource`, `InputMap`, etc.). Detalle en [`docs/agents/godot-engine.md`](docs/agents/godot-engine.md). Referencia de **assets de terceros** (CC0/MIT y enlaces): [`docs/third-party-assets.md`](docs/third-party-assets.md).
+
 **Combates y momentos a priori “tipo MMO” (referencia: WoW):** simulación en **tiempo real** donde el jugador lanza **acciones** (instantáneas, casteos, canales) con **cadencia** (GCD o equivalente), **cooldowns** y lectura del espacio. **No** es el marco por defecto el combate **por turnos**; si aparece algo por turnos, debe ser un **subsistema acotado** y explícito (p. ej. minijuego), no el supuesto del diseño.
 
 ## Roles de agente (invocación bajo demanda)

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -5,6 +5,7 @@ Estos archivos son **roles opcionales**. No sustituyen a [`AGENTS.md`](../../AGE
 | Agente | Archivo | Invocar cuando… |
 |--------|---------|------------------|
 | Coordinador | [`coordinator.md`](coordinator.md) | Hay varios frentes y querés un orden, criterios de corte y anti-scope creep. |
+| Godot / motor | [`godot-engine.md`](godot-engine.md) | Estructura de escenas, física, señales, recursos, importación; buenas prácticas Godot 4. |
 | Dirección creativa | [`creative-director.md`](creative-director.md) | Pilares del juego, tono, priorización fuerte, decir “no”. |
 | Narrativa | [`narrative-story.md`](narrative-story.md) | Arcos, personajes, diálogos; enlace con datos y triggers. |
 | Simulación tiempo real | [`realtime-simulation.md`](realtime-simulation.md) | Tick, timestep, orden de sistemas, autoridad de estado. |
@@ -20,3 +21,5 @@ Estos archivos son **roles opcionales**. No sustituyen a [`AGENTS.md`](../../AGE
 | QA y telemetría | [`qa-telemetry.md`](qa-telemetry.md) | Casos borde, repro, logs, pruebas de regresión. |
 
 **Uso sugerido en Cursor:** `@docs/agents/<archivo>.md` junto con tu pedido, o pegar el bloque “Mandato” del rol que necesites.
+
+**Assets externos:** ver [`docs/third-party-assets.md`](../third-party-assets.md).

--- a/docs/agents/action-combat.md
+++ b/docs/agents/action-combat.md
@@ -31,3 +31,4 @@ Diseñar el **sistema de habilidades** y su resolución en **tiempo real**: cola
 
 - Con [`realtime-simulation.md`](realtime-simulation.md): orden de tick y timestamps.
 - Con [`ai-encounters.md`](ai-encounters.md): telegrafía de ataques del enemigo y ventanas del jugador.
+- Con [`godot-engine.md`](godot-engine.md): `Area3D`/`ShapeCast3D`/`RayCast3D` para validación espacial, `AnimationTree` si la telegrafía va ligada a animación — sin duplicar reglas fuera del sistema de combate.

--- a/docs/agents/coordinator.md
+++ b/docs/agents/coordinator.md
@@ -17,6 +17,13 @@ Orquestar **qué problema se resuelve ahora**, en **qué orden**, y con **qué a
 3. Elegir **un** archivo de `docs/agents/` como rol principal para la siguiente ronda; el resto queda explícitamente fuera o en “siguiente iteración”.
 4. Exigir **criterio de cierre** medible (jugable, log, test unitario, checklist manual).
 5. Si el juego es **tiempo real por acciones** (estilo MMO), verificar que no se esté diseñando en mentalidad **por turnos** salvo que sea un subsistema aislado (p. ej. minijuego).
+6. Si el cambio toca **Godot** (escenas, scripts, importación), el rol motor por defecto es [`godot-engine.md`](godot-engine.md) — aunque otro rol (combate, movimiento) lidere el diseño del sistema.
+
+## Arte y contenido (decisión de alcance)
+
+- **Etapa temprana (recomendado):** un **solo personaje** sin armas ni anims de combate; entorno mínimo (suelo + pocos props) para validar **movimiento/cámara** y bucle de escena. Lista de fuentes CC0/MIT y enlaces: [`docs/third-party-assets.md`](../third-party-assets.md).
+- **Cuándo traer más arte:** cuando exista un **contrato** claro (p. ej. sockets de mano para armas, o sistema de habilidades que requiera telegrafía). Antes de eso, más assets suelen ser **deuda** sin sistema que los consuma.
+- **Comprar vs hacer:** prototipo → **assets CC0** (Kenney, Poly Haven, Quaternius) o Asset Library con licencia clara; **modelado propio** solo para piezas únicas o cuando el estilo lo exija. No mezclar muchos estilos PBR distintos sin paso de **dirección creativa**.
 
 ## Fuera de mandato
 

--- a/docs/agents/godot-engine.md
+++ b/docs/agents/godot-engine.md
@@ -1,0 +1,40 @@
+# Agente: Godot (motor y buenas prácticas)
+
+## Rol
+
+Asegurar que propuestas técnicas y de arquitectura respeten **cómo Godot quiere que se organice el trabajo**: escenas como composición, nodos con responsabilidad clara, señales para desacoplar, y APIs idiomáticas en **Godot 4.x** (GDScript o C# según el proyecto).
+
+## Cuándo invocarte
+
+- Estructura de carpetas, autoloads, escenas reutilizables, plugins.
+- Dudas entre `_process` vs `_physics_process`, `CharacterBody3D`, `AnimationTree`, UI.
+- Importación de `.glb`/`.gltf`, materiales, luces, rendimiento en 3D.
+
+## Mandato (prioridades)
+
+1. **Escenas y nodos primero** — preferir escenas pequeñas componibles (`PackedScene` instanciadas) antes que jerarquías gigantes en un solo `.tscn`.
+2. **Separar simulación de presentación** — la lógica que define reglas de juego no debería vivir solo en nodos de render; usar capas claras (p. ej. componentes hijos, recursos `.tres`, autoloads acotados).
+3. **Tiempo de Godot** — usar `delta` coherente con el hilo correcto:
+   - Física y empujes que dependen de colisión: preferir **`_physics_process`** para mover `CharacterBody3D` / integrar velocidad.
+   - Cámara suave, UI, interpolación visual: **`_process`** puede ser válido si no rompe invariantes de simulación.
+4. **Señales y grupos** — comunicar eventos (“murió”, “cambió recurso”) con `signal` y/o `Node.add_to_group` en lugar de acoplar referencias globales everywhere.
+5. **Recursos y datos** — stats, definiciones de habilidades, tablas: `Resource` personalizados o datos importados; evitar “números mágicos” dispersos en scripts de escena salvo prototipo muy breve.
+6. **Input** — `InputMap` / acciones nombradas; no hardcodear teclas en la lógica de combate.
+7. **Depuración** — `push_warning` / `push_error` con contexto; opcionalmente `Engine.is_editor_hint()` para código solo editor.
+
+## Anti-patrones Godot
+
+- Lógica masiva en `_ready` sin dividir responsabilidades.
+- Mezclar **UI** (`Control`) que muta estado de combate sin pasar por el mismo canal que usaría el multijugador futuro (duplicar fuentes de verdad).
+- Usar `_process` para movimiento físico que debe ser estable a distintos FPS.
+- `get_node("../../../Algo")` frágil; preferir `%UniqueName`, exportar `NodePath`, o inyección desde la escena padre.
+
+## Coordinación
+
+- Con [`realtime-simulation.md`](realtime-simulation.md): orden de actualización alineado a `_physics_process` y al servidor si existe.
+- Con [`movement-navigation.md`](movement-navigation.md): APIs de `CharacterBody3D`, capas de colisión/máscaras.
+- Con [`ui-hud.md`](ui-hud.md): `CanvasLayer`, tema, y señales hacia el modelo de juego.
+
+## Arte y contenido
+
+Ver [`docs/third-party-assets.md`](../third-party-assets.md) para licencias y packs sugeridos; respetar **import defaults** (mallas, compresión, sombras) y no subir binarios pesados al git sin política clara del repo.

--- a/docs/agents/movement-navigation.md
+++ b/docs/agents/movement-navigation.md
@@ -15,6 +15,7 @@ Cómo el cuerpo del personaje **ocupa espacio** y se desplaza en **tiempo contin
 1. Definir **contrato** entre “intención de movimiento” (input/red) y **estado cinemático** resultante.
 2. Asegurar que habilidades que modifican movimiento (raíces, empujes) tengan **prioridad** y **duración** claras en tiempo real.
 3. Separar **movimiento simulado** de **animación** (blend puede mentir; la hitbox no debería).
+4. En **Godot 3D**, preferir **`CharacterBody3D`** + capas/máscaras de colisión documentadas; movimiento en **`_physics_process`**; usar `move_and_slide` (o equivalente) de forma consistente con gravedad y `floor_snap`.
 
 ## Fuera de mandato
 

--- a/docs/agents/realtime-simulation.md
+++ b/docs/agents/realtime-simulation.md
@@ -16,6 +16,7 @@ Definir el **corazón del bucle**: tick/update, timestep (fijo vs variable), ord
 2. Nombrar **autoridad**: qué sistema puede sobrescribir estado de qué otro.
 3. Tratar **tiempo de juego** como eje explícito: `now`, duraciones, timestamps de fin de efecto, no “paso 3 del turno”.
 4. Si hay red: separar **simulación autoritativa** de **predicción cliente** (aunque sea plan futuro, no mezclar conceptos en un solo PR).
+5. En **Godot**, alinear el pipeline con **`_physics_process` (física)** para estado que afecta colisiones / `CharacterBody3D`, y dejar en **`_process`** lo que sea puramente visual — ver [`godot-engine.md`](godot-engine.md).
 
 ## Fuera de mandato
 

--- a/docs/agents/ui-hud.md
+++ b/docs/agents/ui-hud.md
@@ -14,6 +14,7 @@
 1. Para cada elemento: **fuente de datos** (evento, snapshot, polling controlado) y **frecuencia de actualización**.
 2. Definir **prioridad visual** en combate: qué no puede tapar qué.
 3. Accesibilidad básica: tamaño, color+forma (no solo color), rebinding si aplica.
+4. En **Godot**, HUD en `CanvasLayer` o subviewport dedicado; preferir **señales** o un bus de eventos hacia la UI en lugar de que `Control` llame profundo a nodos de gameplay.
 
 ## Fuera de mandato
 

--- a/docs/agents/world-zones.md
+++ b/docs/agents/world-zones.md
@@ -14,6 +14,7 @@
 1. Definir **identidad de zona** y qué sistemas consultan esa clave (combate ambiental, música, tablas de spawn).
 2. Separar **layout geométrico** de **reglas de fase** (quién decide qué versión del mundo está activa).
 3. Prever **jugadores a distintas fases**: interacción social, party, visibilidad.
+4. En **Godot**, una **zona** puede mapearse a una escena (`*.tscn`) o a un `Area3D` que registra entrada/salida; streaming avanzado solo cuando el MVP lo exija — ver [`godot-engine.md`](godot-engine.md).
 
 ## Fuera de mandato
 

--- a/docs/third-party-assets.md
+++ b/docs/third-party-assets.md
@@ -1,0 +1,35 @@
+# Assets de terceros (referencia)
+
+Lista **orientativa** para prototipo 3D simple (pasto, árboles, decoración, personajes, armas). **Verificar siempre la licencia** en la página de descarga antes de publicar un build comercial.
+
+## Entorno y props (estilo simple / CC0 frecuente)
+
+- **Kenney — Nature Kit** — vegetación y elementos naturales estilizados.  
+  https://kenney.nl/assets/nature-kit  
+- **Kenney — Starter Kit 3D Platformer** — plantilla Godot con modelos CC0 y ejemplo de personaje; útil como referencia de proyecto.  
+  https://github.com/KenneyNL/starter-kit-3d-platformer  
+  También en la Asset Library: https://godotengine.org/asset-library/asset/2120  
+
+## Personajes y animación (CC0 frecuente)
+
+- **Quaternius — Universal Base Characters** — personajes base humanoid-friendly.  
+  https://quaternius.com/packs/universalbasecharacters.html  
+  https://quaternius.itch.io/universal-base-characters  
+- **Quaternius — Universal Animation Library** — librería grande de clips para retargeting.  
+  https://quaternius.com/packs/universalanimationlibrary.html  
+  https://quaternius.itch.io/universal-animation-library  
+
+## Materiales PBR y HDR (CC0)
+
+- **Poly Haven** — texturas, modelos y HDRIs CC0.  
+  https://polyhaven.com/  
+
+## Armas y packs misceláneos
+
+- Buscar en **Godot Asset Library** con filtro “CC0” o “MIT” y revisar el texto de licencia por asset:  
+  https://godotengine.org/asset-library/asset  
+
+## Importación en Godot
+
+- Preferir **glTF 2.0 / `.glb`** cuando exista; revisar escala (1 unidad = 1 metro es una convención habitual) y **root type** en el importador.
+- Para muchos props idénticos, considerar **`MultiMeshInstance3D`** más adelante; en etapa 1, instancias simples están bien.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Este PR adapta la documentación de agentes al desarrollo en **Godot 4.x** y documenta una **política de arte** acorde a la etapa 1 (personaje desarmado, poco entorno).

Cambios:

- `AGENTS.md`: motor Godot 4, enlaces a `docs/agents/godot-engine.md` y `docs/third-party-assets.md`.
- `docs/agents/godot-engine.md`: mandato de buenas prácticas Godot (escenas, `_physics_process` vs `_process`, señales, `Resource`, `InputMap`, anti-patrones).
- `docs/agents/coordinator.md`: decisión explícita de alcance para arte/assets y cuándo escalar contenido.
- Ajustes puntuales en `realtime-simulation`, `movement-navigation`, `ui-hud`, `world-zones`, `action-combat` para enlazar convenciones Godot.
- `docs/third-party-assets.md`: enlaces a packs CC0 conocidos (Kenney, Quaternius, Poly Haven) y Asset Library, más notas breves de importación.

Sin código de proyecto Godot todavía; solo documentación.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f675fb35-d2bc-4526-af47-b18d195f0237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f675fb35-d2bc-4526-af47-b18d195f0237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

